### PR TITLE
Changed subscript declaration to public

### DIFF
--- a/Stash/Stash.swift
+++ b/Stash/Stash.swift
@@ -128,7 +128,7 @@ public final class Stash {
         diskCache.removeAllObjects()
     }
     
-    subscript(index: String) -> NSCoding? {
+    public subscript(index: String) -> NSCoding? {
         get {
             return objectForKey(index)
         }


### PR DESCRIPTION
I installed Stash via CocoaPods and I couldn't access an object with the subscript notation. I noticed it wasn't declared as `public` and so I modified to make it compile correctly. Let me know if this is how it was supposed to work 😉
